### PR TITLE
main: use seperate stream for control characters

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -909,10 +909,6 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.ctrl_token_no_out = true;
         return true;
     }
-    if (arg == "--ctrl-token-fd-out") {
-        params.ctrl_token_fd_out = true;
-        return true;
-    }
     if (arg == "--embedding") {
         params.embedding = true;
         return true;
@@ -1442,9 +1438,6 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  -i, --interactive     run in interactive mode\n");
     printf("  --interactive-specials allow special tokens in user text, in interactive mode\n");
     printf("  --ctrl-token-no-out   control tokens output disabled\n");
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
-    printf("  --ctrl-token-fd-out   control tokens sent to file descriptor 3 out of band\n");
-#endif
     printf("  -cnv, --conversation  run in conversation mode (does not print special tokens and suffix/prefix)\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
     printf("  -cml, --chatml        run in chatml mode (use with ChatML-compatible models)\n");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -905,7 +905,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.interactive_specials = true;
         return true;
     }
-    if (arg == "--ctrl-token-no-out") {
+    if (arg == "--no-special") {
         params.ctrl_token_no_out = true;
         return true;
     }
@@ -1438,7 +1438,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  -i, --interactive     run in interactive mode\n");
     printf("  --interactive-specials allow special tokens in user text, in interactive mode\n");
     printf("  --interactive-first   run in interactive mode and wait for input right away\n");
-    printf("  --ctrl-token-no-out   control tokens output disabled\n");
+    printf("  --no-special          control tokens output disabled\n");
     printf("  -cnv, --conversation  run in conversation mode (does not print special tokens and suffix/prefix)\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
     printf("  -cml, --chatml        run in chatml mode (use with ChatML-compatible models)\n");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -905,6 +905,14 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.interactive_specials = true;
         return true;
     }
+    if (arg == "--ctrl-token-no-out") {
+        params.ctrl_token_no_out = true;
+        return true;
+    }
+    if (arg == "--ctrl-token-fd-out") {
+        params.ctrl_token_fd_out = true;
+        return true;
+    }
     if (arg == "--embedding") {
         params.embedding = true;
         return true;
@@ -1433,7 +1441,10 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --version             show version and build info\n");
     printf("  -i, --interactive     run in interactive mode\n");
     printf("  --interactive-specials allow special tokens in user text, in interactive mode\n");
-    printf("  --interactive-first   run in interactive mode and wait for input right away\n");
+    printf("  --ctrl-token-no-out   control tokens output disabled\n");
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+    printf("  --ctrl-token-fd-out   control tokens sent to file descriptor 3 out of band\n");
+#endif
     printf("  -cnv, --conversation  run in conversation mode (does not print special tokens and suffix/prefix)\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
     printf("  -cml, --chatml        run in chatml mode (use with ChatML-compatible models)\n");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -906,7 +906,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "--no-special") {
-        params.ctrl_token_no_out = true;
+        params.no_special = true;
         return true;
     }
     if (arg == "--embedding") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1437,6 +1437,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --version             show version and build info\n");
     printf("  -i, --interactive     run in interactive mode\n");
     printf("  --interactive-specials allow special tokens in user text, in interactive mode\n");
+    printf("  --interactive-first   run in interactive mode and wait for input right away\n");
     printf("  --ctrl-token-no-out   control tokens output disabled\n");
     printf("  -cnv, --conversation  run in conversation mode (does not print special tokens and suffix/prefix)\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");

--- a/common/common.h
+++ b/common/common.h
@@ -142,6 +142,8 @@ struct gpt_params {
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
     bool interactive_specials = false; // whether to allow special tokens from user, during interactive mode
+    bool ctrl_token_no_out = false; // disable control token output
+    bool ctrl_token_fd_out = false; // enable control token output and redirect it to file descriptor 3
     bool conversation      = false; // conversation mode (does not print special tokens and suffix/prefix)
     bool chatml            = false; // chatml mode (used for models trained on chatml syntax)
     bool prompt_cache_all  = false; // save user input and generations to prompt cache

--- a/common/common.h
+++ b/common/common.h
@@ -143,7 +143,6 @@ struct gpt_params {
     bool interactive       = false; // interactive mode
     bool interactive_specials = false; // whether to allow special tokens from user, during interactive mode
     bool ctrl_token_no_out = false; // disable control token output
-    bool ctrl_token_fd_out = false; // enable control token output and redirect it to file descriptor 3
     bool conversation      = false; // conversation mode (does not print special tokens and suffix/prefix)
     bool chatml            = false; // chatml mode (used for models trained on chatml syntax)
     bool prompt_cache_all  = false; // save user input and generations to prompt cache

--- a/common/common.h
+++ b/common/common.h
@@ -142,7 +142,7 @@ struct gpt_params {
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
     bool interactive_specials = false; // whether to allow special tokens from user, during interactive mode
-    bool ctrl_token_no_out = false; // disable control token output
+    bool no_special        = false; // disable control token output
     bool conversation      = false; // conversation mode (does not print special tokens and suffix/prefix)
     bool chatml            = false; // chatml mode (used for models trained on chatml syntax)
     bool prompt_cache_all  = false; // save user input and generations to prompt cache

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -760,7 +760,7 @@ int main(int argc, char ** argv) {
                 if (!llama_token_is_control_token(llama_get_model(ctx), id)) {
                     // Stream Output Token To Standard Output
                     fprintf(stdout, "%s", token_str.c_str());
-                } else if (!params.ctrl_token_no_out) {
+                } else if (!params.no_special) {
 #ifndef _MSC_VER
                     if (control_token_file_descriptor_is_attached) {
                         // Stream Control Token To Special Token Output. Useful for debugging control token behaviour

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -748,10 +748,11 @@ int main(int argc, char ** argv) {
                     // Stream Output Token To Standard Output
                     fprintf(stdout, "%s", token_str.c_str());
                 } else if (!params.ctrl_token_no_out) {
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#ifndef _MSC_VER
                     if (params.ctrl_token_fd_out) {
                         // Stream Control Token To Special Token Output. Useful for debugging control token behaviour
-                        dprintf(CONTROL_TOKEN_FILE_DESCRIPTOR, "%s", token_str.c_str());
+                        ssize_t result = write(CONTROL_TOKEN_FILE_DESCRIPTOR, token_str.c_str(), token_str.length());
+                        (void) result;
                     }
                     else
 #endif

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -531,9 +531,10 @@ int main(int argc, char ** argv) {
     }
 
 #ifndef _MSC_VER
-    if (fcntl(CONTROL_TOKEN_FILENO, F_GETFL) == -1) {
-        // Control Token File Descriptor has nothing attached to it
-        // make control token file descriptor be an alias of stdout
+    const bool control_token_descriptor_is_attached = fcntl(CONTROL_TOKEN_FILENO, F_GETFL) != -1;
+    if (!control_token_descriptor_is_attached && !params.conversation && sparams.grammar.empty()) {
+        // Control Token File Descriptor has nothing attached to it so make control token file descriptor be an alias of stdout
+        // This is not done however if we are in conversation mode or grammar mode as that is typically discarded
         dup2(STDOUT_FILENO, CONTROL_TOKEN_FILENO);
     }
 #endif

--- a/llama.cpp
+++ b/llama.cpp
@@ -17634,6 +17634,10 @@ bool llama_token_is_eog(const struct llama_model * model, llama_token token) {
     );
 }
 
+bool llama_token_is_control_token(const struct llama_model * model, llama_token token) {
+    return llama_is_control_token(model->vocab, token);
+}
+
 llama_token llama_token_bos(const struct llama_model * model) {
     return model->vocab.special_bos_id;
 }

--- a/llama.h
+++ b/llama.h
@@ -816,6 +816,9 @@ extern "C" {
     // Check if the token is supposed to end generation (end-of-generation, eg. EOS, EOT, etc.)
     LLAMA_API bool llama_token_is_eog(const struct llama_model * model, llama_token token);
 
+    // Identify if Token Id is a control token or a render-able token
+    LLAMA_API bool llama_token_is_control_token(const struct llama_model * model, llama_token token);
+
     // Special tokens
     LLAMA_API llama_token llama_token_bos(const struct llama_model * model); // beginning-of-sentence
     LLAMA_API llama_token llama_token_eos(const struct llama_model * model); // end-of-sentence


### PR DESCRIPTION
Stab at this idea for https://github.com/ggerganov/llama.cpp/pull/6923

> One thing you could do is print the special tokens out of band to file descriptor 3. Then if a shell script doesn't want them, it could either pass a flag to disable them, or simply say 3>/dev/null.